### PR TITLE
Update ModuleServicesConfigurator.cs

### DIFF
--- a/src/Library/Infrastructure/ModuleServicesConfigurator.cs
+++ b/src/Library/Infrastructure/ModuleServicesConfigurator.cs
@@ -13,7 +13,7 @@ namespace NetModular.Module.Quartz.Infrastructure
     {
         public void Configure(IServiceCollection services, IModuleCollection modules, IHostEnvironment env, IConfiguration cfg)
         {
-            services.AddSingleton<ITaskLogger, Core.TaskLogger>();
+            services.AddTransient<ITaskLogger, Core.TaskLogger>();
             services.AddSingleton<ISchedulerListener, SchedulerListener>();
             services.AddQuartz(modules);
         }


### PR DESCRIPTION
单例模式下如果不同job同时写日志jobId不是线程安全会导致日志错乱